### PR TITLE
imgclass: Make errors non-fatal

### DIFF
--- a/imgclass/main.go
+++ b/imgclass/main.go
@@ -114,7 +114,8 @@ func teach(ctx context.Context, cb *classificationbox.Client, modelID string, im
 	bar := pb.StartNew(len(images))
 	for _, image := range images {
 		if err := teachImage(ctx, cb, modelID, image); err != nil {
-			return errors.Wrap(err, image.path)
+			fmt.Printf("Error teaching: %s", err);
+			fmt.Println("Pressing onward...");
 		}
 		bar.Increment()
 	}


### PR DESCRIPTION
Editor's note: I suspect there may be reason that you have to bail out on error?  Just wanted to get the discussion going.

---

If imgclass encounters a corrupt image it will fail and bail out.  Here's
an example in the wild:

    Create new model with 26 classes? (y/n): y
    new model created: 5aaf257815a3e7eb
    Teach and validate Classificationbox with 187198 (80%) random images? (y/n): y
     36023 / 187198 [=========================>--------------------------------------------------------------------------------------------------------]  19.24% 8h23m1s2018/03/18 21:50:55 teaching: Tween_Leggings/image_2IlTxYG.jpeg: classificationbox: 5aaf257815a3e7eb:5aaf257815a3e7eb could not preprocess the input: could not pre process the image for feature 'image': model predict image returns an error Traceback (most recent call last):
      File "/tmp/mb951297289", line 41, in predict_img
      File "/env/local/lib/python2.7/site-packages/PIL/Image.py", line 1743, in resize
        self.load()
      File "/env/local/lib/python2.7/site-packages/PIL/ImageFile.py", line 233, in load
        "(%d bytes not processed)" % len(b))
    IOError: image file is truncated (13 bytes not processed)

This can be particularly annoying while working on large datasets.

Rather than bailing out on error just print the error on soldier onward.